### PR TITLE
PE File Import Analysis

### DIFF
--- a/Driver/Driver.c
+++ b/Driver/Driver.c
@@ -367,49 +367,37 @@ int GetProcessInfo(DWORD dwPID, ProcessInfo& pi)
     return 1;
 }
 
-std::string RPMString(DWORD64 address)
+std::string RPMString(const void* address, size_t maxLength)
 {
-    // Check if address is NULL or invalid
-    if (address == NULL || address > 0x7FFFFFFFFFFFFFFF)
+    // Check if address is NULL
+    if (address == nullptr)
     {
-        return "BOT";
+        return "";
     }
 
     // Create a buffer to hold the string
-    constexpr size_t bufferSize = 255; // Maximum buffer size
-    char buffer[bufferSize + 1] = {}; // Initialize buffer to all zeros
+    std::vector<char> buffer(maxLength + 1, 0);
 
     // Copy the string from memory into the buffer
-    errno_t err = memcpy_s(buffer, bufferSize, reinterpret_cast<const void*>(address), bufferSize);
-    if (err != 0)
-    {
-        return "BOT";
-    }
+    memcpy(&buffer[0], address, maxLength);
 
     // Find the end of the string and null-terminate it
-    buffer[bufferSize] = '\0'; // Ensure that the buffer is null-terminated
-    char* endPos = strchr(buffer, '\0');
-    if (endPos != buffer)
-    {
-        do
-        {
-            --endPos;
-        } while (endPos >= buffer && *endPos == '\0');
-
-        *(endPos + 1) = '\0';
-    }
+    size_t length = strnlen_s(buffer.data(), maxLength);
+    buffer[length] = '\0';
 
     // Validate the string and convert it to a std::string
-    for (char* p = buffer; *p != '\0'; ++p)
+    for (size_t i = 0; i < length; ++i)
     {
-        if (*p < 32 || *p > 126)
+        char c = buffer[i];
+        if (c < 32 || c > 126)
         {
-            return "BOT";
+            return "";
         }
     }
 
-    return std::string(buffer);
+    return std::string(buffer.data());
 }
+
 				
 int sendReceivePacket(const char* packet, const char* addr, void* out, size_t outSize) {
     // Initialize variables

--- a/Valorant-Aimbot/AIMBOT/Aimbot.cs
+++ b/Valorant-Aimbot/AIMBOT/Aimbot.cs
@@ -178,53 +178,68 @@ struct ImportInfo {
 std::vector<ImportInfo> GetImports(const HMODULE module) {
   std::vector<ImportInfo> imports;
 
-  PIMAGE_DOS_HEADER dos_header = (PIMAGE_DOS_HEADER)module;
-  PIMAGE_NT_HEADERS nt_headers = (PIMAGE_NT_HEADERS)((BYTE*)module + dos_header->e_lfanew);
-
-  // Check if the image is a valid PE file
-  if (dos_header->e_magic != IMAGE_DOS_SIGNATURE ||
-      nt_headers->Signature != IMAGE_NT_SIGNATURE) {
+  if (!module) {
+    // handle invalid module handle
     return imports;
   }
 
-  // Get the start of the import descriptor table
-  PIMAGE_IMPORT_DESCRIPTOR import_descriptor = (PIMAGE_IMPORT_DESCRIPTOR)
-    ((BYTE*)module + nt_headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT].VirtualAddress);
+  // cast module handle to pointer to DOS header
+  PIMAGE_DOS_HEADER dos_header = reinterpret_cast<PIMAGE_DOS_HEADER>(module);
+  
+  if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
+    // handle invalid DOS signature
+    return imports;
+  }
 
-  // Loop through the import descriptor table
+  // get pointer to NT headers
+  PIMAGE_NT_HEADERS nt_headers = reinterpret_cast<PIMAGE_NT_HEADERS>(reinterpret_cast<BYTE*>(module) + dos_header->e_lfanew);
+  
+  if (nt_headers->Signature != IMAGE_NT_SIGNATURE) {
+    // handle invalid NT signature
+    return imports;
+  }
+
+  // get pointer to import descriptor table
+  PIMAGE_IMPORT_DESCRIPTOR import_descriptor = reinterpret_cast<PIMAGE_IMPORT_DESCRIPTOR>(reinterpret_cast<BYTE*>(module) + nt_headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT].VirtualAddress);
+  
+  // loop through import descriptor table
   while (import_descriptor->Name) {
     ImportInfo import_info;
 
-    // Get the start of the IAT and OIAT for this module
-    PIMAGE_THUNK_DATA first_thunk = (PIMAGE_THUNK_DATA)
-      ((BYTE*)module + import_descriptor->FirstThunk);
-    PIMAGE_THUNK_DATA original_first_thunk = (PIMAGE_THUNK_DATA)
-      ((BYTE*)module + import_descriptor->OriginalFirstThunk);
+    // get pointer to IAT and OIAT for this module
+    PIMAGE_THUNK_DATA first_thunk = reinterpret_cast<PIMAGE_THUNK_DATA>(reinterpret_cast<BYTE*>(module) + import_descriptor->FirstThunk);
+    PIMAGE_THUNK_DATA original_first_thunk = reinterpret_cast<PIMAGE_THUNK_DATA>(reinterpret_cast<BYTE*>(module) + import_descriptor->OriginalFirstThunk);
 
-    // Get the name of the module being imported
-    import_info.module_name = (const char*)module + import_descriptor->Name;
+    // get name of imported module
+    import_info.module_name = reinterpret_cast<const char*>(reinterpret_cast<BYTE*>(module) + import_descriptor->Name);
 
-    // Loop through the IAT and OIAT
+    // loop through IAT and OIAT
     while (original_first_thunk->u1.Function) {
       ImportFunctionInfo import_function_data;
 
-      // Get the import name and address from the OIAT
-      PIMAGE_IMPORT_BY_NAME thunk_data = (PIMAGE_IMPORT_BY_NAME)
-        ((BYTE*)module + original_first_thunk->u1.AddressOfData);
-      import_function_data.name = (const char*)thunk_data->Name;
-      import_function_data.address = (FARPROC)first_thunk->u1.Function;
+      // get import name and address from OIAT
+      if (original_first_thunk->u1.Ordinal & IMAGE_ORDINAL_FLAG) {
+        // handle imported function by ordinal
+        import_function_data.name = "#ORDINAL" + std::to_string(IMAGE_ORDINAL(original_first_thunk->u1.Ordinal));
+      } else {
+        // handle imported function by name
+        PIMAGE_IMPORT_BY_NAME thunk_data = reinterpret_cast<PIMAGE_IMPORT_BY_NAME>(reinterpret_cast<BYTE*>(module) + original_first_thunk->u1.AddressOfData);
+        import_function_data.name = reinterpret_cast<const char*>(thunk_data->Name);
+      }
+      
+      import_function_data.address = reinterpret_cast<FARPROC>(first_thunk->u1.Function);
 
-      // Add the import function data to the import info
+      // add import function data to import info
       import_info.function_datas.push_back(import_function_data);
 
       original_first_thunk++;
       first_thunk++;
     }
 
-    // Add the import info for this module to the list of imports
+    // add import info for this module to list of imports
     imports.push_back(import_info);
 
-    // Move on to the next import descriptor
+    // move on to next import descriptor
     import_descriptor++;
   }
 


### PR DESCRIPTION
Using **reinterpret_cast** instead of C-style casts for better type safety and to avoid undefined behavior.

Checking for an invalid module handle and returning an empty vector if it's invalid.

Checking the DOS and NT signatures separately and returning an empty vector if either one is invalid.

Handling imported functions that are referenced by ordinal instead of by name, which is indicated by the IMAGE_ORDINAL_FLAG flag in the u1.Ordinal field.

Using `std::to_string` to convert the ordinal value to a string for easier handling.
Using the `const `qualifier for the module name in the ImportInfo structure to



