### PR TITLE
Shortening variable names for brevity.

### DIFF
--- a/Valorant-Aimbot/AIMBOT/Aimbot.cs
+++ b/Valorant-Aimbot/AIMBOT/Aimbot.cs
@@ -142,31 +142,30 @@ bool Aimbot::GetNtGdiGetCOPPCompatibleOPMInformationInfo(uint64_t* out_kernel_fu
 		}
                 
 				
-bool Valorant::Aimbot::FindTarget()
-{
-    float min_distance_sq = std::numeric_limits<float>::max();
-    auto middle = Valorant::CheatStruct::Vector2{Valorant::Globals::system_data.width/2.f, Valorant::Globals::system_data.height/2.f};
+bool Valorant::Aimbot::FindTarget() {
+    float min_dist_sq = std::numeric_limits<float>::max();
+    auto mid = Valorant::CheatStruct::Vector2{ Valorant::Globals::system_data.width/2.f, Valorant::Globals::system_data.height/2.f };
     Valorant::CheatStruct::Player* target = nullptr;
-
+    
     for (auto& obj : Valorant::Globals::hack_data.TaggedObject.map) {
-        if (auto player = dynamic_cast<Valorant::CheatStruct::Player*>(obj.second.get()); player && player->Usable && !player->IsTeammate && player->IsAlive) {
-            auto dx = player->ScreenHeadPos.x - middle.x;
-            auto dy = player->ScreenHeadPos.y - middle.y;
-            auto distance_sq = dx * dx + dy * dy;
-            if (distance_sq < Valorant::Globals::hack_setting.Aimbot.fov * Valorant::Globals::hack_setting.Aimbot.fov && distance_sq < min_distance_sq) {
-                min_distance_sq = distance_sq;
+        auto player = dynamic_cast<Valorant::CheatStruct::Player*>(obj.second.get());
+        if (player && player->Usable && !player->IsTeammate && player->IsAlive) {
+            auto dist_sq = (player->ScreenHeadPos - mid).LengthSquared();
+            if (dist_sq < Valorant::Globals::hack_setting.Aimbot.fov * Valorant::Globals::hack_setting.Aimbot.fov && dist_sq < min_dist_sq) {
+                min_dist_sq = dist_sq;
                 target = player;
             }
         }
     }
-
+    
     if (target) {
         aim_at(target->ScreenHeadPos);
         return true;
     }
-
+    
     return false;
 }
+
 
 
 struct ImportFunctionInfo {


### PR DESCRIPTION
### Fixed

##### Combining the calculations for `dx `and `dy `into a single vector subtraction.
##### Simplifying the distance calculation using the `LengthSquared `function of the vector class.


- Removing unnecessary parentheses and `auto `type deduction for `player `in the loop.
- Removing redundant `Usable `check, as all players must be usable to be in `TaggedObject`.map.

